### PR TITLE
Replace filtered/query by bool/must

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ in form of a Python dictionary.
 ```python
 query = {
     "query": {
-        "filtered": {
-            "query": {
+        "bool": {
+            "must": {
                 "match_all": {}
             },
             "filter": {
@@ -513,8 +513,8 @@ Sometimes queries turns in to complex and verbose data structures, to help you
 ```python
 query = {
     "query": {
-        "filtered": {
-            "query": {
+        "bool": {
+            "must": {
                 "match_all": {}
             },
             "filter": {

--- a/lib/toute/document.py
+++ b/lib/toute/document.py
@@ -257,8 +257,8 @@ class Document(with_metaclass(ModelMetaclass, BaseDocument)):
 
         >>> query = {
         ...     "query": {
-        ...         "filtered": {
-        ...             "query": {"match_all": {}},
+        ...         "bool": {
+        ...             "must": {"match_all": {}},
         ...             "filter": {"exists": {"field": "name"}}
         ...         }
         ...     }
@@ -310,8 +310,8 @@ class Document(with_metaclass(ModelMetaclass, BaseDocument)):
         if ids:
             query = {
                 "query": {
-                    "filtered": {
-                        "query": {"match_all": {}},
+                    "bool": {
+                        "must": {"match_all": {}},
                         "filter": {"ids": {"values": list(ids)}}
                     }
                 }

--- a/lib/toute/fields.py
+++ b/lib/toute/fields.py
@@ -12,7 +12,7 @@ from toute.utils.validation import FieldValidator
 __all__ = [
     'IntegerField', 'LongField', 'ShortField', 'KeywordField', 'FloatField',
     'DateField', 'UuidField', 'BooleanField', 'GeoPointField',
-    'ArrayField', 'ObjectField', 'TextField'
+    'ArrayField', 'ObjectField', 'TextField', 'DoubleField'
 ]
 
 

--- a/lib/toute/utils/payload/base.py
+++ b/lib/toute/utils/payload/base.py
@@ -93,13 +93,13 @@ class Payload(object):
 
     def as_dict(self):
         if self._filter and self._query:
-            self._struct['query'] = Query.filtered(
+            self._struct['query'] = Query.bool(
                 filter=self._filter,
-                query=self._query
+                must=self._query
             )
 
         elif self._filter:
-            self._struct['query'] = Query.filtered(
+            self._struct['query'] = Query.bool(
                 filter=self._filter
             )
 

--- a/lib/toute/utils/payload/queries.py
+++ b/lib/toute/utils/payload/queries.py
@@ -13,7 +13,7 @@ QUERIES = {
         'args': ({'fields': []}, 'query')
     },
     'bool': {
-        'kwargs': ({('must', 'must_not', 'should'): ['_query']},)
+        'kwargs': ({('must', 'must_not', 'should', 'filter'): ['_query']},)
     },
     'boost': {
         'kwargs': ({('positive', 'negative'): '_query'})


### PR DESCRIPTION
The `filtered` query was [removed in Elasticsearch 5.0](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_search_changes.html#_deprecated_queries_removed) so the `filter` method in Document was raising an exception when used with the `ids` parameter: `elasticsearch.exceptions.RequestError: TransportError(400, 'parsing_exception', 'no [query] registered for [filtered]')`. The same exception was raised when using Filter in a call to `search`.

This PR also:
- Replaces a few other references to `filtered`
- Adds `filter` as a valid keyword for `bool` in Query
- Adds `Doublefield` to `__all__` in fields.py