### PR TITLE
Make include_type_name mapping param optional

### DIFF
--- a/lib/toute/mapping.py
+++ b/lib/toute/mapping.py
@@ -19,9 +19,10 @@ class Mapping(object):
     operation must be done at elasticsearch index creation.
 
     """
-    def __init__(self, document_class=None, enable_all=True):
+    def __init__(self, document_class=None, enable_all=True, include_type_name=True):
         self.document_class = document_class
         self.enable_all = enable_all
+        self.include_type_name = include_type_name
 
     def _generate(self, doc_class):
         """
@@ -58,7 +59,7 @@ class Mapping(object):
             return es.indices.create(
                 index=self.document_class._index,
                 body={"mappings": self.generate()},
-                params={"include_type_name": "true"}
+                params={"include_type_name": "true"} if self.include_type_name else {}
             )
 
     def build_configuration(self, models_to_mapping, custom_settings, es=None):


### PR DESCRIPTION
The `include_type_name` mapping parameter was added in 6.8 (defaults to `true`), kept in 7.x (defaults to `false`) and will be removed in 8.x ([Schedule for removal of mapping types](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/removal-of-types.html#_schedule_for_removal_of_mapping_types)). In Elasticsearch versions which don't know about this parameter (< 6.8 from what the link above says), the `save` method in Mapping is raising an exception: `elasticsearch.exceptions.RequestError: TransportError(400, 'illegal_argument_exception', 'request [/testing] contains unrecognized parameter: [include_type_name]')`.

This PR doesn't change default behavior but allows a class to pass a `include_type_name=False` to Mapping to avoid this error.