### PR TITLE
Check if result's hits.total field is an object or an int

### DIFF
--- a/lib/toute/bases/result.py
+++ b/lib/toute/bases/result.py
@@ -89,7 +89,8 @@ class ResultSet(object):
         return eh.bulk(self._es, actions, **meta if meta else {})
 
     def count(self):
-        return min(self._size, self.meta.get('hits', {}).get('total')['value'])
+        total = self.meta.get('hits', {}).get('total')
+        return min(self._size, total.get('value') if type(total) is dict else total)
 
     def to_dict(self, *args, **kwargs):
         """


### PR DESCRIPTION
`hits.total` [became an object in ES 7.0](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#hits-total-now-object-search-response), before that it was an int. Check if it's indeed an object before trying to access `hits.total.value`. If it's not, just return `hits.total`.