### PR TITLE
Fix tests

### DIFF
--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -28,7 +28,7 @@ def test_query_must_not_by_ids():
 def test_filter_must_terms_must_not_ids():
     raw_query = {
         'query': {
-            'filtered': {
+            'bool': {
                 'filter': {
                     'bool': {
                         'must': [


### PR DESCRIPTION
Left a `filtered` keyword in one of the tests. It compares a raw query (contained the `filtered` keyword) with a query built using toute's Payload and Filter (didn't contain this keyword after PR #2). Should work now.