### PR TITLE
Check attribute include_type_name when creating index mapping

### DIFF
--- a/lib/toute/mapping.py
+++ b/lib/toute/mapping.py
@@ -132,7 +132,11 @@ class Mapping(object):
                 es
             )
             for index, settings in configurations.items():
-                es.indices.create(index=index, body=settings)
+                es.indices.create(
+                    index=index,
+                    body=settings,
+                    params={"include_type_name": "true"} if self.include_type_name else {}
+                )
         else:
             mapped_models = [x for x in models_to_mapping]
             for model in mapped_models:


### PR DESCRIPTION
Hey, in PR #3 I forgot to add the `include_type_name` optional parameter in one of the `es.indices.create()` calls. This parameter is needed to create indexes with the default type (`_doc`) in ES 6.x and 7.x.